### PR TITLE
Transforma referencia de arquivos em links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Conteúdo baseado do método [Diceware](http://world.std.com/~reinhold/diceware.
 
 Estes PDFs podem ser usados para imprimir o livreto de 40 páginas + capa, em formato A5:
 
-`livreto/dadoware-capa.pdf`: capa para imprimir a 4 cores
+[livreto/dadoware-capa.pdf](livreto/dadoware-capa.pdf): capa para imprimir a 4 cores
 
-`livreto/dadoware-intro.pdf`: introdução e instruções de uso (4 páginas, P&B)
+[livreto/dadoware-intro.pdf](livreto/dadoware-intro.pdf): introdução e instruções de uso (4 páginas, P&B)
 
-`livreto/dadoware-lista.pdf`: lista de palavras (36 páginas, P&B)
+[livreto/dadoware-lista.pdf](livreto/dadoware-lista.pdf): lista de palavras (36 páginas, P&B)
 
 Os arquivos `.ODT` no diretório `livreto/` são documentos de LibreOffice editáveis com todas as 40 páginas do miolo do livreto.
 
@@ -23,6 +23,6 @@ Os arquivos `.ODT` no diretório `livreto/` são documentos de LibreOffice edit�
 
 **Método Diceware**: http://world.std.com/~reinhold/diceware.html
 
-`fontes/com_acentos.txt`: sub-conjunto licenciado de http://www.corpusdoportugues.org/
+[fontes/com_acentos.txt](fontes/com_acentos.txt): sub-conjunto licenciado de http://www.corpusdoportugues.org/
 
-`fontes/dicewarekit.txt`: http://world.std.com/~reinhold/dicewarekit.html (não usamos)
+[fontes/dicewarekit.txt](fontes/dicewarekit.txt): http://world.std.com/~reinhold/dicewarekit.html (não usamos)

--- a/README.md
+++ b/README.md
@@ -10,19 +10,14 @@ Conteúdo baseado do método [Diceware](http://world.std.com/~reinhold/diceware.
 
 Estes PDFs podem ser usados para imprimir o livreto de 40 páginas + capa, em formato A5:
 
-[livreto/dadoware-capa.pdf](livreto/dadoware-capa.pdf): capa para imprimir a 4 cores
-
-[livreto/dadoware-intro.pdf](livreto/dadoware-intro.pdf): introdução e instruções de uso (4 páginas, P&B)
-
-[livreto/dadoware-lista.pdf](livreto/dadoware-lista.pdf): lista de palavras (36 páginas, P&B)
+- [livreto/dadoware-capa.pdf](livreto/dadoware-capa.pdf): capa para imprimir a 4 cores
+- [livreto/dadoware-intro.pdf](livreto/dadoware-intro.pdf): introdução e instruções de uso (4 páginas, P&B)
+- [livreto/dadoware-lista.pdf](livreto/dadoware-lista.pdf): lista de palavras (36 páginas, P&B)
 
 Os arquivos `.ODT` no diretório `livreto/` são documentos de LibreOffice editáveis com todas as 40 páginas do miolo do livreto.
 
-
 ## Fontes de dados
 
-**Método Diceware**: http://world.std.com/~reinhold/diceware.html
-
-[fontes/com_acentos.txt](fontes/com_acentos.txt): sub-conjunto licenciado de http://www.corpusdoportugues.org/
-
-[fontes/dicewarekit.txt](fontes/dicewarekit.txt): http://world.std.com/~reinhold/dicewarekit.html (não usamos)
+- **Método Diceware**: http://world.std.com/~reinhold/diceware.html
+- [fontes/com_acentos.txt](fontes/com_acentos.txt): sub-conjunto licenciado de http://www.corpusdoportugues.org/
+- [fontes/dicewarekit.txt](fontes/dicewarekit.txt): http://world.std.com/~reinhold/dicewarekit.html (não usamos)


### PR DESCRIPTION
As referencias para arquivos locais podem ser convertidas para links para facilitar o acesso ao conteudo.

[Mudanças renderizadas](https://github.com/bltavares/dadoware/blob/patch-1/README.md)
